### PR TITLE
use System.lineSeparator() instead of hardcoded lineseparator

### DIFF
--- a/src/com/greentube/javaconverter/CodePrinter.java
+++ b/src/com/greentube/javaconverter/CodePrinter.java
@@ -89,7 +89,7 @@ public class CodePrinter
     public void println() 
     {
         try 
-        {   ow.write("\n");
+        {   ow.write(System.lineSeparator());
             linehasstarted=false;            
         }
         catch (IOException e) 


### PR DESCRIPTION
Using \r\n instead of just \n on windows will avoid many warnings in Visual Studio.